### PR TITLE
Update rake [CVE-2020-8130]

### DIFF
--- a/spyscape-bootstrap.gemspec
+++ b/spyscape-bootstrap.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "sass"
 
   spec.add_development_dependency "bundler", "~> 1.14"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 13.0"
 end


### PR DESCRIPTION
[GitHub was reporting][1] a security vulnerability in Rake, identified in [CVE-2020-8130][2].

> There is an OS command injection vulnerability in Ruby Rake before
> 12.3.3 in Rake::FileList when supplying a filename that begins with
> the pipe character |.

This gem doesn't have any custom rake tasks, and I believe it's probably only included in the gemspec because that's what the template tends to add. However, we should at least update it to close off the security alert -- and a lack of any real dependency means updating to the very latest major version (13.x) is viable.

[1]: https://github.com/spyscape/spyscape-bootstrap/network/alert/spyscape-bootstrap.gemspec/rake/open
[2]: https://github.com/advisories/GHSA-jppv-gw3r-w3q8